### PR TITLE
fix(ui): add error handling, empty states for Lab/Cashier/Nurse + fix…

### DIFF
--- a/Features/Cashier/ViewModels/CashierPanelViewModel.cs
+++ b/Features/Cashier/ViewModels/CashierPanelViewModel.cs
@@ -17,6 +17,7 @@ public partial class CashierPanelViewModel : HealthCenter.Desktop.ViewModels.Vie
     [ObservableProperty] private Invoice? _selectedInvoice;
     [ObservableProperty] private string _selectedPaymentMethod = "Cash";
     [ObservableProperty] private string _statusMessage = string.Empty;
+    [ObservableProperty] private bool _hasNoInvoices;
 
     public ObservableCollection<string> PaymentMethods { get; } = new()
         { "Cash", "Card", "Insurance" };
@@ -29,13 +30,23 @@ public partial class CashierPanelViewModel : HealthCenter.Desktop.ViewModels.Vie
 
     private void LoadInvoices()
     {
-        var invoices = _db.Invoices
-            .Include(i => i.Patient)
-            .Where(i => i.Status == InvoiceStatus.Pending)
-            .OrderByDescending(i => i.CreatedAt)
-            .ToList();
+        try
+        {
+            var invoices = _db.Invoices
+                .Include(i => i.Patient)
+                .Where(i => i.Status == InvoiceStatus.Pending)
+                .OrderByDescending(i => i.CreatedAt)
+                .ToList();
 
-        PendingInvoices = new ObservableCollection<Invoice>(invoices);
+            PendingInvoices = new ObservableCollection<Invoice>(invoices);
+            HasNoInvoices = PendingInvoices.Count == 0;
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"خطأ في تحميل الفواتير: {ex.Message}";
+            PendingInvoices = new ObservableCollection<Invoice>();
+            HasNoInvoices = true;
+        }
     }
 
     [RelayCommand]
@@ -47,27 +58,35 @@ public partial class CashierPanelViewModel : HealthCenter.Desktop.ViewModels.Vie
             return;
         }
 
-        var method = SelectedPaymentMethod switch
+        try
         {
-            "Card" => PaymentMethod.Card,
-            "Insurance" => PaymentMethod.Insurance,
-            _ => PaymentMethod.Cash
-        };
+            var method = SelectedPaymentMethod switch
+            {
+                "Card" => PaymentMethod.Card,
+                "Insurance" => PaymentMethod.Insurance,
+                _ => PaymentMethod.Cash
+            };
 
-        SelectedInvoice.Status = InvoiceStatus.Paid;
-        SelectedInvoice.PaymentMethod = method;
-        SelectedInvoice.PaidAt = DateTime.UtcNow;
+            SelectedInvoice.Status = InvoiceStatus.Paid;
+            SelectedInvoice.PaymentMethod = method;
+            SelectedInvoice.PaidAt = DateTime.UtcNow;
 
-        _db.SaveChanges();
+            _db.SaveChanges();
 
-        StatusMessage = $"تم تحديد فاتورة المريض {SelectedInvoice.Patient?.FullName} كمدفوعة.";
-        LoadInvoices();
+            StatusMessage = $"تم تحديد فاتورة المريض {SelectedInvoice.Patient?.FullName} كمدفوعة.";
+            LoadInvoices();
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"خطأ في تحديث الفاتورة: {ex.Message}";
+        }
     }
 
     [RelayCommand]
     private void RefreshInvoices()
     {
         LoadInvoices();
-        StatusMessage = "تم تحديث قائمة الفواتير.";
+        if (string.IsNullOrEmpty(StatusMessage) || !StatusMessage.StartsWith("خطأ"))
+            StatusMessage = "تم تحديث قائمة الفواتير.";
     }
 }

--- a/Features/Cashier/Views/CashierPanelView.axaml
+++ b/Features/Cashier/Views/CashierPanelView.axaml
@@ -30,7 +30,8 @@
                                Foreground="#1E293B" Margin="0,0,0,12"/>
                     <ListBox Grid.Row="1" ItemsSource="{Binding PendingInvoices}"
                              SelectedItem="{Binding SelectedInvoice}"
-                             Background="Transparent">
+                             Background="Transparent"
+                             IsVisible="{Binding !HasNoInvoices}">
                         <ListBox.ItemTemplate>
                             <DataTemplate>
                                 <Border Padding="14,10" CornerRadius="6" Background="#F8FAFC"
@@ -52,6 +53,14 @@
                             </DataTemplate>
                         </ListBox.ItemTemplate>
                     </ListBox>
+                    <StackPanel Grid.Row="1" IsVisible="{Binding HasNoInvoices}"
+                                VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="8">
+                        <TextBlock Text="💰" FontSize="40" HorizontalAlignment="Center"/>
+                        <TextBlock Text="لا توجد فواتير معلقة حالياً" FontSize="15"
+                                   Foreground="#94A3B8" HorizontalAlignment="Center"/>
+                        <TextBlock Text="ستظهر الفواتير عند إتمام زيارات المرضى" FontSize="12"
+                                   Foreground="#CBD5E1" HorizontalAlignment="Center"/>
+                    </StackPanel>
                 </Grid>
             </Border>
 

--- a/Features/Lab/ViewModels/LabPanelViewModel.cs
+++ b/Features/Lab/ViewModels/LabPanelViewModel.cs
@@ -18,6 +18,7 @@ public partial class LabPanelViewModel : HealthCenter.Desktop.ViewModels.ViewMod
     [ObservableProperty] private LabTest? _selectedTest;
     [ObservableProperty] private string _resultNotes = string.Empty;
     [ObservableProperty] private string _statusMessage = string.Empty;
+    [ObservableProperty] private bool _hasNoTests;
 
     public LabPanelViewModel()
     {
@@ -27,14 +28,24 @@ public partial class LabPanelViewModel : HealthCenter.Desktop.ViewModels.ViewMod
 
     private void LoadTests()
     {
-        var tests = _db.LabTests
-            .Include(t => t.Patient)
-            .Include(t => t.RequestedBy)
-            .Where(t => t.Status != LabTestStatus.Completed)
-            .OrderByDescending(t => t.RequestedAt)
-            .ToList();
+        try
+        {
+            var tests = _db.LabTests
+                .Include(t => t.Patient)
+                .Include(t => t.RequestedBy)
+                .Where(t => t.Status != LabTestStatus.Completed)
+                .OrderByDescending(t => t.RequestedAt)
+                .ToList();
 
-        RequestedTests = new ObservableCollection<LabTest>(tests);
+            RequestedTests = new ObservableCollection<LabTest>(tests);
+            HasNoTests = RequestedTests.Count == 0;
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"خطأ في تحميل الفحوصات: {ex.Message}";
+            RequestedTests = new ObservableCollection<LabTest>();
+            HasNoTests = true;
+        }
     }
 
     [RelayCommand]
@@ -46,24 +57,32 @@ public partial class LabPanelViewModel : HealthCenter.Desktop.ViewModels.ViewMod
             return;
         }
 
-        var tech = AuthService.Instance.CurrentUser;
+        try
+        {
+            var tech = AuthService.Instance.CurrentUser;
 
-        SelectedTest.Status = LabTestStatus.Completed;
-        SelectedTest.ResultNotes = ResultNotes;
-        SelectedTest.PerformedById = tech?.Id;
-        SelectedTest.CompletedAt = DateTime.UtcNow;
+            SelectedTest.Status = LabTestStatus.Completed;
+            SelectedTest.ResultNotes = ResultNotes;
+            SelectedTest.PerformedById = tech?.Id;
+            SelectedTest.CompletedAt = DateTime.UtcNow;
 
-        _db.SaveChanges();
-        StatusMessage = $"تم تحديث نتيجة فحص: {SelectedTest.TestName}";
+            _db.SaveChanges();
+            StatusMessage = $"تم تحديث نتيجة فحص: {SelectedTest.TestName}";
 
-        ResultNotes = string.Empty;
-        LoadTests();
+            ResultNotes = string.Empty;
+            LoadTests();
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"خطأ في حفظ النتيجة: {ex.Message}";
+        }
     }
 
     [RelayCommand]
     private void RefreshTests()
     {
         LoadTests();
-        StatusMessage = "تم تحديث قائمة الفحوصات.";
+        if (string.IsNullOrEmpty(StatusMessage) || !StatusMessage.StartsWith("خطأ"))
+            StatusMessage = "تم تحديث قائمة الفحوصات.";
     }
 }

--- a/Features/Lab/Views/LabPanelView.axaml
+++ b/Features/Lab/Views/LabPanelView.axaml
@@ -30,7 +30,8 @@
                                Foreground="#1E293B" Margin="0,0,0,12"/>
                     <ListBox Grid.Row="1" ItemsSource="{Binding RequestedTests}"
                              SelectedItem="{Binding SelectedTest}"
-                             Background="Transparent">
+                             Background="Transparent"
+                             IsVisible="{Binding !HasNoTests}">
                         <ListBox.ItemTemplate>
                             <DataTemplate>
                                 <Border Padding="14,10" CornerRadius="6" Background="#F8FAFC"
@@ -47,6 +48,14 @@
                             </DataTemplate>
                         </ListBox.ItemTemplate>
                     </ListBox>
+                    <StackPanel Grid.Row="1" IsVisible="{Binding HasNoTests}"
+                                VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="8">
+                        <TextBlock Text="📋" FontSize="40" HorizontalAlignment="Center"/>
+                        <TextBlock Text="لا توجد فحوصات مطلوبة حالياً" FontSize="15"
+                                   Foreground="#94A3B8" HorizontalAlignment="Center"/>
+                        <TextBlock Text="ستظهر الفحوصات هنا عندما يطلبها الأطباء" FontSize="12"
+                                   Foreground="#CBD5E1" HorizontalAlignment="Center"/>
+                    </StackPanel>
                 </Grid>
             </Border>
 

--- a/Features/Nurse/ViewModels/NursePanelViewModel.cs
+++ b/Features/Nurse/ViewModels/NursePanelViewModel.cs
@@ -21,6 +21,7 @@ public partial class NursePanelViewModel : HealthCenter.Desktop.ViewModels.ViewM
     [ObservableProperty] private string _heartRate = string.Empty;
     [ObservableProperty] private string _weight = string.Empty;
     [ObservableProperty] private string _statusMessage = string.Empty;
+    [ObservableProperty] private bool _hasNoPatients;
 
     public NursePanelViewModel()
     {
@@ -30,15 +31,25 @@ public partial class NursePanelViewModel : HealthCenter.Desktop.ViewModels.ViewM
 
     private void LoadQueue()
     {
-        var today = DateTime.Today;
-        var tickets = _db.QueueTickets
-            .Include(q => q.Patient)
-            .Where(q => q.CreatedAt.Date == today &&
-                        (q.Status == TicketStatus.Waiting || q.Status == TicketStatus.AwaitingRecall))
-            .OrderBy(q => q.TicketNumber)
-            .ToList();
+        try
+        {
+            var today = DateTime.Today;
+            var tickets = _db.QueueTickets
+                .Include(q => q.Patient)
+                .Where(q => q.CreatedAt.Date == today &&
+                            (q.Status == TicketStatus.Waiting || q.Status == TicketStatus.AwaitingRecall))
+                .OrderBy(q => q.TicketNumber)
+                .ToList();
 
-        WaitingQueue = new ObservableCollection<QueueTicket>(tickets);
+            WaitingQueue = new ObservableCollection<QueueTicket>(tickets);
+            HasNoPatients = WaitingQueue.Count == 0;
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"خطأ في تحميل قائمة الانتظار: {ex.Message}";
+            WaitingQueue = new ObservableCollection<QueueTicket>();
+            HasNoPatients = true;
+        }
     }
 
     [RelayCommand]
@@ -50,56 +61,71 @@ public partial class NursePanelViewModel : HealthCenter.Desktop.ViewModels.ViewM
             return;
         }
 
-        // Find or initialize a Visit for this patient today
-        var today = DateTime.Today;
-        var visit = _db.Visits.FirstOrDefault(v =>
-            v.PatientId == SelectedTicket.PatientId &&
-            v.VisitDate.Date == today);
-
-        if (visit == null)
+        try
         {
-            // Get current nurse
-            var nurse = AuthService.Instance.CurrentUser;
+            // Find or initialize a Visit for this patient today
+            var today = DateTime.Today;
+            var visit = _db.Visits.FirstOrDefault(v =>
+                v.PatientId == SelectedTicket.PatientId &&
+                v.VisitDate.Date == today);
 
-            // Doctor must be set — try to find one
-            var doctor = _db.Users.FirstOrDefault(u => u.Role == UserRole.Doctor || u.Role == UserRole.SuperAdmin);
-            if (doctor == null)
+            if (visit == null)
             {
-                StatusMessage = "لا يوجد طبيب مسجّل في النظام.";
-                return;
+                // Get current nurse
+                var nurse = AuthService.Instance.CurrentUser;
+
+                // Doctor must be set — try to find one
+                var doctor = _db.Users.FirstOrDefault(u => u.Role == UserRole.Doctor || u.Role == UserRole.SuperAdmin);
+                if (doctor == null)
+                {
+                    StatusMessage = "لا يوجد طبيب مسجّل في النظام.";
+                    return;
+                }
+
+                visit = new Visit
+                {
+                    PatientId = SelectedTicket.PatientId,
+                    DoctorId = doctor.Id,
+                    NurseId = nurse?.Id,
+                    VisitDate = DateTime.Now,
+                    CreatedAt = DateTime.UtcNow
+                };
+                _db.Visits.Add(visit);
             }
 
-            visit = new Visit
-            {
-                PatientId = SelectedTicket.PatientId,
-                DoctorId = doctor.Id,
-                NurseId = nurse?.Id,
-                VisitDate = DateTime.Now,
-                CreatedAt = DateTime.UtcNow
-            };
-            _db.Visits.Add(visit);
+            // Save vitals
+            if (!string.IsNullOrWhiteSpace(BloodPressure)) visit.BloodPressure = BloodPressure;
+            if (decimal.TryParse(Temperature, out var temp)) visit.Temperature = temp;
+            if (int.TryParse(HeartRate, out var hr)) visit.HeartRate = hr;
+            if (decimal.TryParse(Weight, out var wt)) visit.Weight = wt;
+
+            // Advance ticket status so the Doctor panel picks up the patient
+            SelectedTicket.Status = TicketStatus.Present;
+
+            _db.SaveChanges();
+            StatusMessage = $"تم حفظ العلامات الحيوية وإرسال المريض {SelectedTicket.Patient?.FullName} إلى الطبيب";
+
+            // Clear fields
+            BloodPressure = string.Empty;
+            Temperature = string.Empty;
+            HeartRate = string.Empty;
+            Weight = string.Empty;
+            SelectedTicket = null;
+
+            // Reload queue — patient is no longer Waiting
+            LoadQueue();
         }
-
-        // Save vitals
-        if (!string.IsNullOrWhiteSpace(BloodPressure)) visit.BloodPressure = BloodPressure;
-        if (decimal.TryParse(Temperature, out var temp)) visit.Temperature = temp;
-        if (int.TryParse(HeartRate, out var hr)) visit.HeartRate = hr;
-        if (decimal.TryParse(Weight, out var wt)) visit.Weight = wt;
-
-        _db.SaveChanges();
-        StatusMessage = $"تم حفظ العلامات الحيوية للمريض: {SelectedTicket.Patient?.FullName}";
-
-        // Clear fields
-        BloodPressure = string.Empty;
-        Temperature = string.Empty;
-        HeartRate = string.Empty;
-        Weight = string.Empty;
+        catch (Exception ex)
+        {
+            StatusMessage = $"خطأ في حفظ العلامات الحيوية: {ex.Message}";
+        }
     }
 
     [RelayCommand]
     private void RefreshQueue()
     {
         LoadQueue();
-        StatusMessage = "تم تحديث قائمة المرضى.";
+        if (string.IsNullOrEmpty(StatusMessage) || !StatusMessage.StartsWith("خطأ"))
+            StatusMessage = "تم تحديث قائمة المرضى.";
     }
 }

--- a/Features/Nurse/Views/NursePanelView.axaml
+++ b/Features/Nurse/Views/NursePanelView.axaml
@@ -29,7 +29,7 @@
                 <Grid RowDefinitions="Auto,*">
                     <TextBlock Grid.Row="0" Text="قائمة الانتظار اليوم" FontWeight="SemiBold" FontSize="15"
                                Foreground="#1E293B" Margin="0,0,0,12"/>
-                    <ScrollViewer Grid.Row="1">
+                    <ScrollViewer Grid.Row="1" IsVisible="{Binding !HasNoPatients}">
                         <ListBox ItemsSource="{Binding WaitingQueue}"
                                  SelectedItem="{Binding SelectedTicket}"
                                  Background="Transparent">
@@ -53,6 +53,14 @@
                             </ListBox.ItemTemplate>
                         </ListBox>
                     </ScrollViewer>
+                    <StackPanel Grid.Row="1" IsVisible="{Binding HasNoPatients}"
+                                VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="8">
+                        <TextBlock Text="🏥" FontSize="40" HorizontalAlignment="Center"/>
+                        <TextBlock Text="لا يوجد مرضى في الانتظار حالياً" FontSize="15"
+                                   Foreground="#94A3B8" HorizontalAlignment="Center"/>
+                        <TextBlock Text="سيظهر المرضى عند تسجيلهم من الاستقبال" FontSize="12"
+                                   Foreground="#CBD5E1" HorizontalAlignment="Center"/>
+                    </StackPanel>
                 </Grid>
             </Border>
 
@@ -95,7 +103,7 @@
                                    IsVisible="{Binding StatusMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"/>
                     </StackPanel>
 
-                    <Button Grid.Row="3" Content="حفظ العلامات الحيوية"
+                    <Button Grid.Row="3" Content="حفظ وإرسال للطبيب"
                             Command="{Binding SaveVitalsCommand}"
                             HorizontalAlignment="Stretch" HorizontalContentAlignment="Center"
                             Padding="0,12" FontSize="15" FontWeight="SemiBold"


### PR DESCRIPTION
… nurse-to-doctor workflow

- Wrap LoadTests/LoadInvoices/LoadQueue in try/catch with Arabic error messages
- Add empty-state UI with icons for all three panels when no data exists
- Fix nurse workflow: SaveVitals now advances ticket to Present status so the Doctor panel can pick up the patient (was stuck in Waiting)
- Update nurse button text to 'حفظ وإرسال للطبيب'